### PR TITLE
test fix after headers were renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nubus_master.v - Master controller
 
 nubus_slave.v - Slave controller
 
-nubus_inc.sv - Included to various files definition of NuBus signals
+nubus.svh - Included to various files definition of NuBus signals
 
 nubus_arbiter_tb.sv - Arbiter's test bench
 
@@ -53,7 +53,7 @@ nubus_master_tb.sv - Master controller test bench (CPU access to slave with NuBu
 
 nubus_memory.sv - Memory controller used for tests
 
-cpu_bus.v - Encoder from PicoRV bus to this NuBus controller
+nubus_cpubus.v - Encoder from PicoRV bus to this NuBus controller
 
 ## Makefile
 

--- a/nubus.v
+++ b/nubus.v
@@ -83,7 +83,7 @@ module nubus
     output        mem_myslot
   );
 
-  `include "nubus_inc.sv"
+  `include "nubus.svh"
 
    // ==========================================================================
    // Colock and reset

--- a/nubus_master_tb.sv
+++ b/nubus_master_tb.sv
@@ -2,7 +2,7 @@
 
 module nubus_master_tb ();
 
-`include "nubus_tb_inc.sv"
+`include "nubus_tb.svh"
 
    // Simplifyed memory layout (see nubus_master.v)
    parameter SIMPLE_MAP = 0;

--- a/nubus_slave_tb.sv
+++ b/nubus_slave_tb.sv
@@ -48,6 +48,8 @@ module nubus_slave_tb ();
    tri1 [31:0]         mem_rdata;
    tri1                mem_myslot;
    tri1                mem_myexp;
+   tri1 	       mem_stdslot;
+   tri1 	       mem_local;       
 
    tri0                cpu_valid;
    tri1 [31:0]         cpu_addr;
@@ -86,8 +88,10 @@ module nubus_slave_tb ();
       .mem_addr(mem_addr),
       .mem_wdata(mem_wdata),
       .mem_rdata(mem_rdata),
-      .mem_slot(mem_myslot),
-      .mem_super(mem_myep),
+      .mem_myslot(mem_myslot),
+      .mem_super(mem_myexp),
+      .mem_stdslot(mem_stdslot),
+      .mem_local(mem_local),
 
        // Master device
       .cpu_valid(cpu_valid),


### PR DESCRIPTION
Fix for #1 ; there's also a 'mem_myep' signal in the slave TB that I think should be 'mem_myexp'.